### PR TITLE
ci: 升级 GitHub Actions 到 Node 24 运行时

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,19 +16,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 检出分支
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: 安装pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
         with:
           run_install: |
             - recursive: true
             - args: [--global, "vercel", "@dotenvx/dotenvx", "tsx", "turbo"]
 
       - name: 安装node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22.14.0
           cache: pnpm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,19 +24,19 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: 安装pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
         with:
           run_install: |
             - recursive: true
             - args: [--global, "vercel", "@dotenvx/dotenvx", "tsx", "turbo", "npm"]
 
       - name: 安装node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22.14.0
           cache: pnpm
@@ -82,7 +82,7 @@ jobs:
 
       - name: 触发部署工作流
         if: steps.changesets.outputs.published == 'true'
-        uses: peter-evans/repository-dispatch@v3
+        uses: peter-evans/repository-dispatch@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           event-type: deploy-after-release

--- a/.github/workflows/use-vercel-cli-and-turbo-build-1.yaml
+++ b/.github/workflows/use-vercel-cli-and-turbo-build-1.yaml
@@ -14,7 +14,7 @@ jobs:
   Deploy-Production:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@main
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/use-vercel-cli-build-try-1.yaml
+++ b/.github/workflows/use-vercel-cli-build-try-1.yaml
@@ -16,7 +16,7 @@ jobs:
   Deploy-Production:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@main
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/use-vercel-cli-build-try-2.yaml
+++ b/.github/workflows/use-vercel-cli-build-try-2.yaml
@@ -16,7 +16,7 @@ jobs:
   Deploy-Production:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@main
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/use-vercel-cli-build-try-3.yaml
+++ b/.github/workflows/use-vercel-cli-build-try-3.yaml
@@ -18,7 +18,7 @@ jobs:
   Deploy-Production:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@main
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/use-vercel-cli-build-try-4.yaml
+++ b/.github/workflows/use-vercel-cli-build-try-4.yaml
@@ -59,7 +59,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 检出分支
-        uses: actions/checkout@main
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/vercel-build.yaml
+++ b/.github/workflows/vercel-build.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 检出项目
-        uses: actions/checkout@main
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/vercel-deploy-tool.yaml
+++ b/.github/workflows/vercel-deploy-tool.yaml
@@ -50,12 +50,12 @@ jobs:
           fi
 
       - name: 检出分支
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: 安装pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
         with:
           # 项目提供了packageManager，故我们不提供该配置
           # version: 9
@@ -65,7 +65,7 @@ jobs:
             - args: [--global, "vercel@latest", "@dotenvx/dotenvx", "tsx", "turbo"]
 
       - name: 安装node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22.14.0
           cache: pnpm


### PR DESCRIPTION
## 变更

- 升级 GitHub workflow 中会触发 Node.js 20 actions deprecation 的 `uses:` action 版本
- 覆盖 GitHub 官方 action，以及已确认支持 Node 24 的第三方 action
- 保留项目自身构建/发布用的 Node 版本配置，不把 action runtime 与项目运行时混在一起

## 原因

GitHub Actions runner 正在从 Node 20 action runtime 迁移到 Node 24。旧版 JavaScript action 会在 workflow 注解中出现 Node.js 20 deprecation 警告，后续 runner 迁移后还可能影响执行稳定性。

## 验证

- 静态检查 workflow `uses:` 引用，确认已知 Node 20 action pin 已迁移到 Node 24 版本
- 未改动项目依赖、源码或构建脚本