### PR TITLE
🔧 config(memorix): 移除高频噪音 hooks 配置，仅保留会话生命周期事件

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,141 +1,130 @@
 {
-	"permissions": {
-		"allow": [],
-		"deny": [],
-		"additionalDirectories": []
-	},
-	"not-use-now-hooks": {
-		"Stop": [
-			{
-				"hooks": [
-					{
-						"type": "command",
-						"command": "pnpm dlx @ruan-cat/claude-notifier@latest task-complete --message \"本地settings.json配置：任务完成\""
-					},
-					{
-						"type": "command",
-						"command": "pnpm dlx @ruan-cat/claude-notifier@latest check-and-notify"
-					}
-				]
-			}
-		],
-		"UserPromptSubmit": [
-			{
-				"hooks": [
-					{
-						"type": "command",
-						"command": "pnpm dlx @ruan-cat/claude-notifier@latest check-and-notify"
-					}
-				]
-			}
-		],
-		"PreToolUse": [
-			{
-				"hooks": [
-					{
-						"type": "command",
-						"command": "pnpm dlx @ruan-cat/claude-notifier@latest check-and-notify"
-					}
-				]
-			}
-		],
-		"PostToolUse": [
-			{
-				"hooks": [
-					{
-						"type": "command",
-						"command": "pnpm dlx @ruan-cat/claude-notifier@latest check-and-notify"
-					}
-				]
-			}
-		],
-		"SessionStart": [
-			{
-				"hooks": [
-					{
-						"type": "command",
-						"command": "pnpm dlx @ruan-cat/claude-notifier@latest check-and-notify"
-					}
-				]
-			}
-		],
-		"SessionEnd": [
-			{
-				"hooks": [
-					{
-						"type": "command",
-						"command": "pnpm dlx @ruan-cat/claude-notifier@latest check-and-notify"
-					}
-				]
-			}
-		],
-		"SubagentStop": [
-			{
-				"hooks": [
-					{
-						"type": "command",
-						"command": "pnpm dlx @ruan-cat/claude-notifier@latest check-and-notify"
-					}
-				]
-			}
-		]
-	},
-	"version": 1,
-	"hooks": {
-		"SessionStart": [
-			{
-				"hooks": [
-					{
-						"type": "command",
-						"command": "memorix.cmd hook",
-						"timeout": 10
-					}
-				]
-			}
-		],
-		"PostToolUse": [
-			{
-				"hooks": [
-					{
-						"type": "command",
-						"command": "memorix.cmd hook",
-						"timeout": 10
-					}
-				]
-			}
-		],
-		"UserPromptSubmit": [
-			{
-				"hooks": [
-					{
-						"type": "command",
-						"command": "memorix.cmd hook",
-						"timeout": 10
-					}
-				]
-			}
-		],
-		"PreCompact": [
-			{
-				"hooks": [
-					{
-						"type": "command",
-						"command": "memorix.cmd hook",
-						"timeout": 10
-					}
-				]
-			}
-		],
-		"Stop": [
-			{
-				"hooks": [
-					{
-						"type": "command",
-						"command": "memorix.cmd hook",
-						"timeout": 10
-					}
-				]
-			}
-		]
-	}
+  "permissions": {
+    "allow": [],
+    "deny": [],
+    "additionalDirectories": []
+  },
+  "not-use-now-hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "pnpm dlx @ruan-cat/claude-notifier@latest task-complete --message \"本地settings.json配置：任务完成\""
+          },
+          {
+            "type": "command",
+            "command": "pnpm dlx @ruan-cat/claude-notifier@latest check-and-notify"
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "pnpm dlx @ruan-cat/claude-notifier@latest check-and-notify"
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "pnpm dlx @ruan-cat/claude-notifier@latest check-and-notify"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "pnpm dlx @ruan-cat/claude-notifier@latest check-and-notify"
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "pnpm dlx @ruan-cat/claude-notifier@latest check-and-notify"
+          }
+        ]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "pnpm dlx @ruan-cat/claude-notifier@latest check-and-notify"
+          }
+        ]
+      }
+    ],
+    "SubagentStop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "pnpm dlx @ruan-cat/claude-notifier@latest check-and-notify"
+          }
+        ]
+      }
+    ]
+  },
+  "version": 1,
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "memorix.cmd hook",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "memorix.cmd hook",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "PreCompact": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "memorix.cmd hook",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "memorix.cmd hook",
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/.cursor/hooks.json
+++ b/.cursor/hooks.json
@@ -1,40 +1,25 @@
 {
-	"version": 1,
-	"hooks": {
-		"sessionStart": [
-			{
-				"command": "memorix.cmd hook"
-			}
-		],
-		"beforeSubmitPrompt": [
-			{
-				"command": "memorix.cmd hook"
-			}
-		],
-		"afterFileEdit": [
-			{
-				"command": "memorix.cmd hook"
-			}
-		],
-		"beforeShellExecution": [
-			{
-				"command": "memorix.cmd hook"
-			}
-		],
-		"afterMCPExecution": [
-			{
-				"command": "memorix.cmd hook"
-			}
-		],
-		"preCompact": [
-			{
-				"command": "memorix.cmd hook"
-			}
-		],
-		"stop": [
-			{
-				"command": "memorix.cmd hook"
-			}
-		]
-	}
+  "version": 1,
+  "hooks": {
+    "sessionStart": [
+      {
+        "command": "memorix.cmd hook"
+      }
+    ],
+    "beforeSubmitPrompt": [
+      {
+        "command": "memorix.cmd hook"
+      }
+    ],
+    "preCompact": [
+      {
+        "command": "memorix.cmd hook"
+      }
+    ],
+    "stop": [
+      {
+        "command": "memorix.cmd hook"
+      }
+    ]
+  }
 }

--- a/.gemini/settings.json
+++ b/.gemini/settings.json
@@ -1,57 +1,44 @@
 {
-	"version": 1,
-	"hooks": {
-		"SessionStart": [
-			{
-				"matcher": "*",
-				"hooks": [
-					{
-						"name": "memorix-session-start",
-						"type": "command",
-						"command": "memorix.cmd hook",
-						"description": "Load memorix context at session start"
-					}
-				]
-			}
-		],
-		"AfterTool": [
-			{
-				"matcher": "*",
-				"hooks": [
-					{
-						"name": "memorix-after-tool",
-						"type": "command",
-						"command": "memorix.cmd hook",
-						"description": "Record tool usage in memorix"
-					}
-				]
-			}
-		],
-		"AfterAgent": [
-			{
-				"matcher": "*",
-				"hooks": [
-					{
-						"name": "memorix-after-agent",
-						"type": "command",
-						"command": "memorix.cmd hook",
-						"description": "Record agent response in memorix"
-					}
-				]
-			}
-		],
-		"PreCompress": [
-			{
-				"matcher": "*",
-				"hooks": [
-					{
-						"name": "memorix-pre-compress",
-						"type": "command",
-						"command": "memorix.cmd hook",
-						"description": "Save context before compression"
-					}
-				]
-			}
-		]
-	}
+  "version": 1,
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "name": "memorix-session-start",
+            "type": "command",
+            "command": "memorix.cmd hook",
+            "description": "Load memorix context at session start"
+          }
+        ]
+      }
+    ],
+    "AfterAgent": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "name": "memorix-after-agent",
+            "type": "command",
+            "command": "memorix.cmd hook",
+            "description": "Record agent response in memorix"
+          }
+        ]
+      }
+    ],
+    "PreCompress": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "name": "memorix-pre-compress",
+            "type": "command",
+            "command": "memorix.cmd hook",
+            "description": "Save context before compression"
+          }
+        ]
+      }
+    ]
+  }
 }


### PR DESCRIPTION
## Summary

- 移除 Memorix hooks 中的高频噪音触发器（PostToolUse、AfterTool、afterFileEdit、afterMCPExecution、beforeShellExecution、post_write_code、post_run_command、post_mcp_tool_use）
- 仅保留会话生命周期事件 hooks（SessionStart、UserPromptSubmit/beforeSubmitPrompt、PreCompact、Stop）
- 涉及 .claude/settings.local.json、.cursor/hooks.json、.gemini/settings.json

## Why

这些高频 hooks 每次工具调用/文件编辑/命令执行都会触发 Memorix 记录，产生大量无意义的噪音记忆（占比超 63%），严重影响记忆检索质量。

## Verification

- 确认保留的 hooks 仍能在会话开始、用户提交、压缩前、会话结束时正常记录
- 确认移除的 hooks 不再产生每次操作的噪音记录